### PR TITLE
Update Debug_Extension.rb

### DIFF
--- a/Utility/Debug_Extension.rb
+++ b/Utility/Debug_Extension.rb
@@ -473,7 +473,7 @@ class Scene_Base
           eval(code)
           Sound.play_ok
           break
-        rescue
+        rescue Exception => ex
           Sound.play_buzzer
         end
       end


### PR DESCRIPTION
Bug fix for when the person inputs code that causes an Exception not caught by default, like compile time Exceptions, such as unbalanced statements.
