### PR TITLE
Fix gauge drawing

### DIFF
--- a/Core/Ace_Core_Engine.rb
+++ b/Core/Ace_Core_Engine.rb
@@ -735,12 +735,12 @@ class Window_Base < Window
   #--------------------------------------------------------------------------
   def draw_current_and_max_values(dx, dy, dw, current, max, color1, color2)
     total = current.group + "/" + max.group
-    if dw < text_size(total).width + text_size(Vocab.hp).width
+    if dw < text_size(total).width + text_size(Vocab.hp_a).width
       change_color(color1)
       draw_text(dx, dy, dw, line_height, current.group, 2)
     else
-      xr = dx + text_size(Vocab.hp).width
-      dw -= text_size(Vocab.hp).width
+      xr = dx + text_size(Vocab.hp_a).width
+      dw -= text_size(Vocab.hp_a).width
       change_color(color2)
       text = "/" + max.group
       draw_text(xr, dy, dw, line_height, text, 2)


### PR DESCRIPTION
When drawing gauges, Vocab.hp was used to determine spacing. But Vocab.hp is the long form, e.g. "Life points". Changed it to use Vocab.hp_a, e.g. "LP". This is still kind of dumb, as Vocab.hp_a could have a different width than Vocab.mp_a, but in most games they're equal length.