### PR TITLE
Bugfix for the Enemy level script

### DIFF
--- a/Gameplay/Enemy_Levels.rb
+++ b/Gameplay/Enemy_Levels.rb
@@ -490,8 +490,8 @@ class Game_Enemy < Game_Battler
   alias game_enemy_exp_elv exp
   def exp
     base = game_enemy_exp_elv
-    per = enemy.level_growth[8][1]
-    set = enemy.level_growth[8][2]
+    per = enemy.level_growth[9][1]
+    set = enemy.level_growth[9][2]
     total = eval(YEA::ENEMY_LEVEL::STAT_FORMULA)
     return total.to_i
   end
@@ -502,8 +502,8 @@ class Game_Enemy < Game_Battler
   alias game_enemy_gold_elv gold
   def gold
     base = game_enemy_gold_elv
-    per = enemy.level_growth[9][1]
-    set = enemy.level_growth[9][2]
+    per = enemy.level_growth[8][1]
+    set = enemy.level_growth[8][2]
     total = eval(YEA::ENEMY_LEVEL::STAT_FORMULA)
     return total.to_i
   end


### PR DESCRIPTION
Lines 493-494 and 505-506 exp and gold array have been interchanged.
Gold is supposed to be 8, Exp is 9. See lines 150-151.
Due to this bug the <exp: +x per level> and <exp: +x% per level> notetags are controlling gold values.
And <gold: +x per level> and <gold: +x% per level> notetags are controlling exp value.